### PR TITLE
feat(llm): add default model/provider to auto configure the driver

### DIFF
--- a/mcontainer/cli.py
+++ b/mcontainer/cli.py
@@ -163,6 +163,10 @@ def create_session(
     gid: Optional[int] = typer.Option(
         None, "--gid", help="Group ID to run the container as (defaults to host user)"
     ),
+    model: Optional[str] = typer.Option(None, "--model", "-m", help="Model to use"),
+    provider: Optional[str] = typer.Option(
+        None, "--provider", "-p", help="Provider to use"
+    ),
     ssh: bool = typer.Option(False, "--ssh", help="Start SSH server in the container"),
 ) -> None:
     """Create a new MC session
@@ -269,6 +273,8 @@ def create_session(
             uid=target_uid,
             gid=target_gid,
             ssh=ssh,
+            model=model,
+            provider=provider,
         )
 
     if session:

--- a/mcontainer/drivers/goose/mc-init.sh
+++ b/mcontainer/drivers/goose/mc-init.sh
@@ -49,7 +49,7 @@ if [ -d /root/.local/bin ]; then
     echo "Copying /root/.local/bin to /home/mcuser/.local/bin..."
     mkdir -p /home/mcuser/.local/bin
     cp -r /root/.local/bin/* /home/mcuser/.local/bin/
-    chown -R $MC_USER_ID:$MC_GROUP_ID /home/mcuser/.local/bin
+    chown -R $MC_USER_ID:$MC_GROUP_ID /home/mcuser/.local
 fi
 
 # Start SSH server only if explicitly enabled
@@ -158,16 +158,16 @@ else
     echo "Warning: update-goose-config.py script not found. Goose configuration will not be updated."
 fi
 
-# Mark initialization as complete
-echo "=== MC Initialization completed at $(date) ==="
-echo "INIT_COMPLETE=true" > /init.status
-
 # Run the user command first, if set, as mcuser
 if [ -n "$MC_RUN_COMMAND" ]; then
-    echo '--- Executing initial command: $MC_RUN_COMMAND ---';
+    echo "--- Executing initial command: $MC_RUN_COMMAND ---";
     gosu mcuser sh -c "$MC_RUN_COMMAND"; # Run user command as mcuser
     COMMAND_EXIT_CODE=$?;
     echo "--- Initial command finished (exit code: $COMMAND_EXIT_CODE) ---";
 fi;
+
+# Mark initialization as complete
+echo "=== MC Initialization completed at $(date) ==="
+echo "INIT_COMPLETE=true" > /init.status
 
 exec gosu mcuser "$@"

--- a/mcontainer/drivers/goose/update-goose-config.py
+++ b/mcontainer/drivers/goose/update-goose-config.py
@@ -30,6 +30,26 @@ def update_config():
             if "extensions" not in config_data:
                 config_data["extensions"] = {}
 
+    # Add default developer extension
+    config_data["extensions"]["developer"] = {
+        "enabled": True,
+        "name": "developer",
+        "timeout": 300,
+        "type": "builtin",
+    }
+
+    # Update goose configuration with model and provider from environment variables
+    goose_model = os.environ.get("MC_MODEL")
+    goose_provider = os.environ.get("MC_PROVIDER")
+
+    if goose_model:
+        config_data["GOOSE_MODEL"] = goose_model
+        print(f"Set GOOSE_MODEL to {goose_model}")
+
+    if goose_provider:
+        config_data["GOOSE_PROVIDER"] = goose_provider
+        print(f"Set GOOSE_PROVIDER to {goose_provider}")
+
     # Get MCP information from environment variables
     mcp_count = int(os.environ.get("MCP_COUNT", "0"))
     mcp_names_str = os.environ.get("MCP_NAMES", "[]")

--- a/mcontainer/models.py
+++ b/mcontainer/models.py
@@ -104,11 +104,13 @@ class Session(BaseModel):
     project: Optional[str] = None
     created_at: str
     ports: Dict[int, int] = Field(default_factory=dict)
-    mcps: List[str] = Field(default_factory=list)  # List of MCP server names
-    run_command: Optional[str] = None  # Command executed on start
-    uid: Optional[int] = None  # Store UID used
-    gid: Optional[int] = None  # Store GID used
-    ssh: bool = False  # Whether SSH server is enabled
+    mcps: List[str] = Field(default_factory=list)
+    run_command: Optional[str] = None
+    uid: Optional[int] = None
+    gid: Optional[int] = None
+    model: Optional[str] = None
+    provider: Optional[str] = None
+    ssh: bool = False
 
 
 class Config(BaseModel):

--- a/mcontainer/user_config.py
+++ b/mcontainer/user_config.py
@@ -94,6 +94,8 @@ class UserConfigManager:
                 "networks": [],  # Default networks to connect to (besides mc-network)
                 "volumes": [],  # Default volumes to mount, format: "source:dest"
                 "mcps": [],  # Default MCP servers to connect to
+                "model": "claude-3-5-sonnet-latest",  # Default LLM model to use
+                "provider": "anthropic",  # Default LLM provider to use
             },
             "services": {
                 "langfuse": {},


### PR DESCRIPTION
### **User description**
Based on @kevdevg works in #5


___

### **PR Type**
Enhancement


___

### **Description**
- Add model/provider CLI options

- Auto-configure Goose with selected model/provider

- Store model/provider in session metadata

- Set sensible defaults (claude-3-5-sonnet/anthropic)


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cli.py</strong><dd><code>Add model and provider CLI options</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

mcontainer/cli.py

<li>Added <code>--model</code> and <code>--provider</code> command-line options to the <br><code>create_session</code> function<br> <li> Pass these new parameters to the container creation function


</details>


  </td>
  <td><a href="https://github.com/Monadical-SAS/mcontainer/pull/7/files#diff-c18cedba8be9969d2c10109968cb56c68dc86a34c05ae6b6a6738e246c6384e0">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>container.py</strong><dd><code>Implement model/provider handling in container</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

mcontainer/container.py

<li>Store model and provider in container labels<br> <li> Pass model/provider values to session creation<br> <li> Set environment variables for model/provider from user config if not <br>explicitly provided<br> <li> Include model and provider in session metadata


</details>


  </td>
  <td><a href="https://github.com/Monadical-SAS/mcontainer/pull/7/files#diff-1ce15a6bcd57ec41c0044f8adf5a0e5b6c143c17004a6e1979fe38397f56db9f">+18/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>update-goose-config.py</strong><dd><code>Update Goose config with model/provider</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

mcontainer/drivers/goose/update-goose-config.py

<li>Add default developer extension to Goose configuration<br> <li> Update Goose configuration with model and provider from environment <br>variables<br> <li> Set GOOSE_MODEL and GOOSE_PROVIDER in config if provided


</details>


  </td>
  <td><a href="https://github.com/Monadical-SAS/mcontainer/pull/7/files#diff-1b00643f15322c2103082c3cf6a55ea6ebfff95fd5686e2c40da40b5f4c2d8be">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>models.py</strong><dd><code>Add model/provider fields to Session</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

mcontainer/models.py

<li>Added <code>model</code> and <code>provider</code> fields to the Session model<br> <li> Both fields are optional strings with default value of None


</details>


  </td>
  <td><a href="https://github.com/Monadical-SAS/mcontainer/pull/7/files#diff-5774ddab28c8cc7c65f48cf456ad2ebd3909bcfc27048a21f198bd1d85ae9da3">+7/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>user_config.py</strong><dd><code>Add default model/provider to config</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

mcontainer/user_config.py

<li>Added default model configuration (<code>claude-3-5-sonnet-latest</code>)<br> <li> Added default provider configuration (<code>anthropic</code>)


</details>


  </td>
  <td><a href="https://github.com/Monadical-SAS/mcontainer/pull/7/files#diff-401b9b734b0f02fcc44bd2698101758c702532cc7d14cd67ab713ab269750846">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mc-init.sh</strong><dd><code>Fix initialization script issues</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

mcontainer/drivers/goose/mc-init.sh

<li>Fixed ownership of entire <code>.local</code> directory instead of just <code>.local/bin</code><br> <li> Fixed string interpolation for MC_RUN_COMMAND message<br> <li> Moved initialization completion marker after command execution


</details>


  </td>
  <td><a href="https://github.com/Monadical-SAS/mcontainer/pull/7/files#diff-c16f071be82e73f53063bd4213edaa6fdc775227acba80893cb3feed21840604">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>