### PR TITLE
feat: add ripgrep and openssh-client in images

### DIFF
--- a/cubbi/images/goose/Dockerfile
+++ b/cubbi/images/goose/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.12-slim
 
 LABEL maintainer="team@monadical.com"
-LABEL description="Goose with MCP servers for Cubbi"
+LABEL description="Goose for Cubbi"
 
 # Install system dependencies including gosu for user switching and shadow for useradd/groupadd
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -17,6 +17,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     nano \
     tmux \
     git-core \
+    ripgrep \
+    openssh-client \
     vim \
     && rm -rf /var/lib/apt/lists/*
 

--- a/cubbi/images/opencode/Dockerfile
+++ b/cubbi/images/opencode/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.12-slim
 
 LABEL maintainer="team@monadical.com"
-LABEL description="Goose with MCP servers for Cubbi"
+LABEL description="Opencode for Cubbi"
 
 # Install system dependencies including gosu for user switching and shadow for useradd/groupadd
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -17,6 +17,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     nano \
     tmux \
     git-core \
+    ripgrep \
+    openssh-client \
     vim \
     && rm -rf /var/lib/apt/lists/*
 
@@ -35,6 +37,7 @@ RUN mkdir -p /opt/node && \
     rm node.tar.gz
 
 ENV PATH="/opt/node/bin:$PATH"
+RUN npm i -g yarn
 RUN npm i -g opencode-ai
 
 # Create app directory


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add ripgrep and openssh-client to Docker images

- Fix image descriptions to be more accurate

- Add yarn package manager to opencode image


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Dockerfile</strong><dd><code>Add ripgrep and openssh-client, fix description</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cubbi/images/goose/Dockerfile

<li>Updated image description from "Goose with MCP servers for Cubbi" to <br>"Goose for Cubbi"<br> <li> Added ripgrep and openssh-client to system dependencies


</details>


  </td>
  <td><a href="https://github.com/Monadical-SAS/cubbi/pull/15/files#diff-50f68c9fbc02f06223dbe1a4c296869746c45281eae493e45174a5cdc7d987ec">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Dockerfile</strong><dd><code>Add ripgrep, openssh-client and yarn, fix description</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cubbi/images/opencode/Dockerfile

<li>Updated image description from "Goose with MCP servers for Cubbi" to <br>"Opencode for Cubbi"<br> <li> Added ripgrep and openssh-client to system dependencies<br> <li> Added yarn global installation via npm


</details>


  </td>
  <td><a href="https://github.com/Monadical-SAS/cubbi/pull/15/files#diff-cf4b8cf299a7dd317f52a64564974290b5052b0d540f51d52715f4ecc713e370">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>