### PR TITLE
feat: add network filtering with domain restrictions

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,9 @@ cubbix /path/to/project
 # Connect to external Docker networks
 cubbix --network teamnet --network dbnet
 
+# Restrict network access to specific domains
+cubbix --domains github.com --domains "api.example.com:443"
+
 # Connect to MCP servers for extended capabilities
 cubbix --mcp github --mcp jira
 

--- a/cubbi/cli.py
+++ b/cubbi/cli.py
@@ -179,6 +179,11 @@ def create_session(
         "-c",
         help="Override configuration values (KEY=VALUE) for this session only",
     ),
+    domains: List[str] = typer.Option(
+        [],
+        "--domains",
+        help="Restrict network access to specified domains/ports (e.g., 'example.com:443', '*.api.com')",
+    ),
     verbose: bool = typer.Option(False, "--verbose", help="Enable verbose logging"),
 ) -> None:
     """Create a new Cubbi session
@@ -302,6 +307,18 @@ def create_session(
     # Combine default networks with user-specified networks, removing duplicates
     all_networks = list(set(default_networks + network))
 
+    # Get default domains from user config
+    default_domains = temp_user_config.get("defaults.domains", [])
+
+    # Combine default domains with user-specified domains
+    all_domains = default_domains + list(domains)
+
+    # Check for conflict between network and domains
+    if all_domains and all_networks:
+        console.print(
+            "[yellow]Warning: --domains cannot be used with --network. Network restrictions will take precedence.[/yellow]"
+        )
+
     # Get default MCPs from user config if none specified
     all_mcps = mcp if isinstance(mcp, list) else []
     if not all_mcps:
@@ -313,6 +330,9 @@ def create_session(
 
     if all_networks:
         console.print(f"Networks: {', '.join(all_networks)}")
+
+    if all_domains:
+        console.print(f"Domain restrictions: {', '.join(all_domains)}")
 
     # Show volumes that will be mounted
     if volume_mounts:
@@ -360,6 +380,7 @@ def create_session(
             ssh=ssh,
             model=final_model,
             provider=final_provider,
+            domains=all_domains,
         )
 
     if session:

--- a/cubbi/cli.py
+++ b/cubbi/cli.py
@@ -182,7 +182,7 @@ def create_session(
     domains: List[str] = typer.Option(
         [],
         "--domains",
-        help="Restrict network access to specified domains/ports (e.g., 'example.com:443', '*.api.com')",
+        help="Restrict network access to specified domains/ports (e.g., 'example.com:443', 'api.github.com')",
     ),
     verbose: bool = typer.Option(False, "--verbose", help="Enable verbose logging"),
 ) -> None:

--- a/cubbi/cli.py
+++ b/cubbi/cli.py
@@ -213,7 +213,6 @@ def create_session(
             else:
                 typed_value = value
             config_overrides[key] = typed_value
-            console.print(f"[blue]Config override: {key} = {typed_value}[/blue]")
         else:
             console.print(
                 f"[yellow]Warning: Ignoring invalid config format: {config_item}. Use KEY=VALUE.[/yellow]"

--- a/cubbi/config.py
+++ b/cubbi/config.py
@@ -64,6 +64,7 @@ class ConfigManager:
             },
             defaults={
                 "image": "goose",
+                "domains": [],
             },
         )
 

--- a/cubbi/models.py
+++ b/cubbi/models.py
@@ -111,5 +111,5 @@ class Config(BaseModel):
     images: Dict[str, Image] = Field(default_factory=dict)
     defaults: Dict[str, object] = Field(
         default_factory=dict
-    )  # Can store strings, booleans, or other values
+    )  # Can store strings, booleans, lists, or other values
     mcps: List[Dict[str, Any]] = Field(default_factory=list)


### PR DESCRIPTION
### **User description**
## Summary
- Add `--domains` flag to restrict container network access to specific domains/ports
- Integrate `monadicalsas/network-filter` Docker image for network isolation
- Support domain patterns like `example.com:443`, `*.api.com`

## Test plan
- [x] Test with single domain: `cubbix --domains github.com .`
- [x] Test with multiple domains: `cubbix --domains github.com --domains "api.example.com:443"`
- [ ] Test with wildcard domains: `cubbix --domains "*.github.com"`
- [ ] Test cleanup when session is closed
- [ ] Verify conflict warning with `--network` option
- [ ] Test default domains configuration in `~/.config/cubbi/config.yaml`


___

### **PR Type**
Enhancement


___

### **Description**
- Network access restriction to specific domains

- Domain pattern support (wildcards, ports)

- Integration with network-filter container

- Configuration via CLI and config file


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cli.py</strong><dd><code>Add domains CLI option and configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cubbi/cli.py

<li>Added <code>--domains</code> CLI option to restrict network access<br> <li> Added handling for default domains from user config<br> <li> Added conflict detection between <code>--domains</code> and <code>--network</code><br> <li> Removed config override logging to prevent API key exposure


</details>


  </td>
  <td><a href="https://github.com/Monadical-SAS/cubbi/pull/22/files#diff-e012b1aac0ad1c955b3f298cc83d74c7611eaf544b7e39a7761731a26899ca94">+21/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>container.py</strong><dd><code>Implement domain restriction with network-filter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cubbi/container.py

<li>Implemented network filtering using <code>monadicalsas/network-filter</code> <br>container<br> <li> Added domain restriction parameter to <code>create_session</code> function<br> <li> Added container lifecycle management for network-filter containers<br> <li> Added cleanup of network-filter containers when sessions are closed


</details>


  </td>
  <td><a href="https://github.com/Monadical-SAS/cubbi/pull/22/files#diff-3b28ba4874d30d75eed051f1cd7fe0c8ab4c29c4add797df1c0835634de804c7">+189/-41</a></td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config.py</strong><dd><code>Add domains to default config</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cubbi/config.py

- Added empty domains list to default configuration


</details>


  </td>
  <td><a href="https://github.com/Monadical-SAS/cubbi/pull/22/files#diff-82dbbf8bb868af355192402b912e0ed72807199b671d82345da94837ffdf63b6">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>models.py</strong><dd><code>Update Config model documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cubbi/models.py

<li>Updated Config model documentation to include lists as possible values


</details>


  </td>
  <td><a href="https://github.com/Monadical-SAS/cubbi/pull/22/files#diff-5078f72ca00338a19cbcb55656a8271059b2b4c6aaa1f100ea0786a79492e3d7">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Add domains usage example to README</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

- Added example of domain restriction usage to README


</details>


  </td>
  <td><a href="https://github.com/Monadical-SAS/cubbi/pull/22/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>