### PR TITLE
fix: remove persistent_configs of images

### DIFF
--- a/cubbi/images/aider/cubbi_image.yaml
+++ b/cubbi/images/aider/cubbi_image.yaml
@@ -74,13 +74,4 @@ volumes:
   - mountPath: /app
     description: Application directory
 
-persistent_configs:
-  - source: "/home/cubbi/.aider"
-    target: "/cubbi-config/aider-settings"
-    type: "directory"
-    description: "Aider configuration and history"
-
-  - source: "/home/cubbi/.cache/aider"
-    target: "/cubbi-config/aider-cache"
-    type: "directory"
-    description: "Aider cache directory"
+persistent_configs: []

--- a/cubbi/images/claudecode/cubbi_image.yaml
+++ b/cubbi/images/claudecode/cubbi_image.yaml
@@ -54,13 +54,4 @@ volumes:
   - mountPath: /app
     description: Application directory
 
-persistent_configs:
-  - source: "/home/cubbi/.claude"
-    target: "/cubbi-config/claude-settings"
-    type: "directory"
-    description: "Claude Code settings and configuration"
-
-  - source: "/home/cubbi/.cache/claude"
-    target: "/cubbi-config/claude-cache"
-    type: "directory"
-    description: "Claude Code cache directory"
+persistent_configs: []

--- a/cubbi/images/crush/cubbi_image.yaml
+++ b/cubbi/images/crush/cubbi_image.yaml
@@ -40,12 +40,4 @@ volumes:
   - mountPath: /app
     description: Application directory
 
-persistent_configs:
-  - source: "/home/cubbi/.config/crush"
-    target: "/cubbi-config/crush-config"
-    type: "directory"
-    description: "Crush configuration directory"
-  - source: "/app/.crush"
-    target: "/cubbi-config/crush-app"
-    type: "directory"
-    description: "Crush application data and sessions"
+persistent_configs: []

--- a/cubbi/images/goose/cubbi_image.yaml
+++ b/cubbi/images/goose/cubbi_image.yaml
@@ -28,8 +28,4 @@ volumes:
   - mountPath: /app
     description: Application directory
 
-persistent_configs:
-  - source: "/app/.goose"
-    target: "/cubbi-config/goose-app"
-    type: "directory"
-    description: "Goose memory"
+persistent_configs: []

--- a/cubbi/images/opencode/cubbi_image.yaml
+++ b/cubbi/images/opencode/cubbi_image.yaml
@@ -13,16 +13,4 @@ volumes:
   - mountPath: /app
     description: Application directory
 
-persistent_configs:
-  - source: "/home/cubbi/.config/opencode"
-    target: "/cubbi-config/config-opencode"
-    type: "directory"
-    description: "Opencode configuration"
-  - source: "/home/cubbi/.local/state/opencode"
-    target: "/cubbi-config/state-opencode"
-    type: "directory"
-    description: "Opencode state"
-  - source: "/home/cubbi/.cache/opencode"
-    target: "/cubbi-config/cache-opencode"
-    type: "directory"
-    description: "Opencode cache"
+persistent_configs: []


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Remove persistent configuration mappings from all images

- Replace with empty persistent_configs arrays


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cubbi_image.yaml</strong><dd><code>Remove Aider persistent configurations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cubbi/images/aider/cubbi_image.yaml

<li>Removed persistent configuration mappings for Aider settings and cache<br> <li> Replaced with empty persistent_configs array


</details>


  </td>
  <td><a href="https://github.com/Monadical-SAS/cubbi/pull/28/files#diff-b69aa7044d0c6a132673b25aa76e7f76b027660fb3bae8388df21730cdf382e8">+1/-10</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>cubbi_image.yaml</strong><dd><code>Remove Claude Code persistent configurations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cubbi/images/claudecode/cubbi_image.yaml

<li>Removed persistent configuration mappings for Claude Code settings and <br>cache<br> <li> Replaced with empty persistent_configs array


</details>


  </td>
  <td><a href="https://github.com/Monadical-SAS/cubbi/pull/28/files#diff-6a5a33d69a955a5f4942f9d4edf886d81c7a90916d4e817f79dba4b56fc22f9a">+1/-10</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>cubbi_image.yaml</strong><dd><code>Remove Crush persistent configurations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cubbi/images/crush/cubbi_image.yaml

<li>Removed persistent configuration mappings for Crush configuration <br>directory<br> <li> Removed persistent configuration mappings for Crush application data<br> <li> Replaced with empty persistent_configs array


</details>


  </td>
  <td><a href="https://github.com/Monadical-SAS/cubbi/pull/28/files#diff-8f11c3d61f05a8cc9542829582fc15cd14c4b03026e32a804647f11b64643ddf">+1/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>cubbi_image.yaml</strong><dd><code>Remove Goose persistent configurations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cubbi/images/goose/cubbi_image.yaml

<li>Removed persistent configuration mapping for Goose memory<br> <li> Replaced with empty persistent_configs array


</details>


  </td>
  <td><a href="https://github.com/Monadical-SAS/cubbi/pull/28/files#diff-5b55f411364f6c2586c2959548b00e6e706e3f7f5fa51d6ea9a3bce68685202c">+1/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>cubbi_image.yaml</strong><dd><code>Remove Opencode persistent configurations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cubbi/images/opencode/cubbi_image.yaml

<li>Removed persistent configuration mappings for Opencode configuration, <br>state, and cache<br> <li> Replaced with empty persistent_configs array


</details>


  </td>
  <td><a href="https://github.com/Monadical-SAS/cubbi/pull/28/files#diff-60d29d49bb356cc5f75c0229f633a8c56849d2170c68ac2fc79b84855f4193c9">+1/-13</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>