### PR TITLE
feat: universal model management for all standard providers

### DIFF
--- a/cubbi/cli.py
+++ b/cubbi/cli.py
@@ -2297,12 +2297,12 @@ def refresh_models(
             console.print(f"[red]Provider '{provider}' not found[/red]")
             return
 
-        if not user_config.is_provider_openai_compatible(provider):
+        if not user_config.supports_model_fetching(provider):
             console.print(
-                f"[red]Provider '{provider}' is not a custom OpenAI provider[/red]"
+                f"[red]Provider '{provider}' does not support model fetching[/red]"
             )
             console.print(
-                "Only providers with type='openai' and custom base_url are supported"
+                "Only providers of supported types (openai, anthropic, google, openrouter) can refresh models"
             )
             return
 
@@ -2328,24 +2328,24 @@ def refresh_models(
         except Exception as e:
             console.print(f"[red]Failed to refresh models for '{provider}': {e}[/red]")
     else:
-        # Refresh models for all OpenAI-compatible providers
-        compatible_providers = user_config.list_openai_compatible_providers()
+        # Refresh models for all model-fetchable providers
+        fetchable_providers = user_config.list_model_fetchable_providers()
 
-        if not compatible_providers:
-            console.print("[yellow]No custom OpenAI providers found[/yellow]")
+        if not fetchable_providers:
             console.print(
-                "Add providers with type='openai' and custom base_url to refresh models"
+                "[yellow]No providers with model fetching support found[/yellow]"
+            )
+            console.print(
+                "Add providers of supported types (openai, anthropic, google, openrouter) to refresh models"
             )
             return
 
-        console.print(
-            f"Refreshing models for {len(compatible_providers)} custom OpenAI providers..."
-        )
+        console.print(f"Refreshing models for {len(fetchable_providers)} providers...")
 
         success_count = 0
         failed_providers = []
 
-        for provider_name in compatible_providers:
+        for provider_name in fetchable_providers:
             try:
                 provider_config = user_config.get_provider(provider_name)
                 with console.status(f"Fetching models from {provider_name}..."):

--- a/cubbi/config.py
+++ b/cubbi/config.py
@@ -14,6 +14,14 @@ BUILTIN_IMAGES_DIR = Path(__file__).parent / "images"
 # Dynamically loaded from images directory at runtime
 DEFAULT_IMAGES = {}
 
+# Default API URLs for standard providers
+PROVIDER_DEFAULT_URLS = {
+    "openai": "https://api.openai.com",
+    "anthropic": "https://api.anthropic.com",
+    "google": "https://generativelanguage.googleapis.com",
+    "openrouter": "https://openrouter.ai/api",
+}
+
 
 class ConfigManager:
     def __init__(self, config_path: Optional[Path] = None):

--- a/cubbi/images/crush/crush_plugin.py
+++ b/cubbi/images/crush/crush_plugin.py
@@ -27,17 +27,28 @@ class CrushPlugin(ToolPlugin):
     def _map_provider_to_crush_format(
         self, provider_name: str, provider_config, is_default_provider: bool = False
     ) -> dict[str, Any] | None:
+        # Handle standard providers without base_url
         if not provider_config.base_url:
             if provider_config.type in STANDARD_PROVIDERS:
+                # Populate models for any standard provider that has models
+                models_list = []
+                if provider_config.models:
+                    for model in provider_config.models:
+                        model_id = model.get("id", "")
+                        if model_id:
+                            models_list.append({"id": model_id, "name": model_id})
+
                 provider_entry = {
                     "api_key": provider_config.api_key,
+                    "models": models_list,
                 }
                 return provider_entry
 
+        # Handle custom providers with base_url
         models_list = []
 
-        # Add all models for OpenAI-compatible providers
-        if provider_config.type == "openai" and provider_config.models:
+        # Add all models for any provider type that has models
+        if provider_config.models:
             for model in provider_config.models:
                 model_id = model.get("id", "")
                 if model_id:

--- a/cubbi/images/crush/crush_plugin.py
+++ b/cubbi/images/crush/crush_plugin.py
@@ -34,10 +34,19 @@ class CrushPlugin(ToolPlugin):
                 }
                 return provider_entry
 
+        models_list = []
+
+        # Add all models for OpenAI-compatible providers
+        if provider_config.type == "openai" and provider_config.models:
+            for model in provider_config.models:
+                model_id = model.get("id", "")
+                if model_id:
+                    models_list.append({"id": model_id, "name": model_id})
+
         provider_entry = {
             "api_key": provider_config.api_key,
             "base_url": provider_config.base_url,
-            "models": [],
+            "models": models_list,
         }
 
         if provider_config.type in STANDARD_PROVIDERS:

--- a/cubbi/user_config.py
+++ b/cubbi/user_config.py
@@ -736,6 +736,22 @@ class UserConfigManager:
         provider_type = provider_config.get("type", "")
         return provider_type == "openai" and provider_config.get("base_url") is not None
 
+    def supports_model_fetching(self, provider_name: str) -> bool:
+        """Check if a provider supports model fetching via API."""
+        from .config import PROVIDER_DEFAULT_URLS
+
+        provider = self.get_provider(provider_name)
+        if not provider:
+            return False
+
+        provider_type = provider.get("type")
+        base_url = provider.get("base_url")
+
+        # Provider supports model fetching if:
+        # 1. It has a custom base_url (OpenAI-compatible), OR
+        # 2. It's a standard provider type that we support
+        return base_url is not None or provider_type in PROVIDER_DEFAULT_URLS
+
     def list_openai_compatible_providers(self) -> List[str]:
         providers = self.list_providers()
         compatible_providers = []
@@ -745,3 +761,14 @@ class UserConfigManager:
                 compatible_providers.append(provider_name)
 
         return compatible_providers
+
+    def list_model_fetchable_providers(self) -> List[str]:
+        """List all providers that support model fetching."""
+        providers = self.list_providers()
+        fetchable_providers = []
+
+        for provider_name in providers.keys():
+            if self.supports_model_fetching(provider_name):
+                fetchable_providers.append(provider_name)
+
+        return fetchable_providers


### PR DESCRIPTION
## Summary
Extends model management from OpenAI-compatible providers only to **all standard providers** (OpenAI, Anthropic, Google, OpenRouter) with provider-specific authentication and response format handling.

## Key Features
- **Universal Provider Support**: All major LLM providers now support model fetching
- **Provider-Specific Authentication**: 
  - Anthropic: `x-api-key` header + API version
  - Google: `x-goog-api-key` header + custom response format  
  - OpenAI/OpenRouter: Bearer token (unchanged)
- **Enhanced CLI**: `cubbi config models refresh` works with all providers
- **Improved Configure UI**: All providers show in model selection (including those without API keys)
- **Plugin Integration**: OpenCode & Crush populate models from all provider types

## Technical Implementation
- Added default API URLs for standard providers
- Enhanced model fetcher with provider-specific handling
- Google API support (unique `{"models": [...]}` format vs `{"data": [...]}`)
- Comprehensive provider detection methods
- Backward compatibility maintained

## Usage
```bash
# Now works with all providers
cubbi config models refresh anthropic
cubbi config models refresh google  
cubbi config models list

# Interactive config shows all providers
cubbi configure
```

## Breaking Changes
- Expands model refresh scope from custom OpenAI providers only to all standard providers
- Users will see more providers available in configuration interfaces

Comprehensive enhancement that provides seamless model management across the entire LLM ecosystem\! 🚀